### PR TITLE
Ref #5 - Fix Java installer (temporary fix)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,14 @@
   args:
     creates: /root/.oracle-license-accepted
 
+- name: Patch the java installer due to some Oracle changes on their website
+  shell: |
+    cd /var/lib/dpkg/info
+    sed -i 's|JAVA_VERSION=8u151|JAVA_VERSION=8u162|' oracle-java8-installer.*
+    sed -i 's|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u151-b12/e758a0de34e24606bca991d704f6dcbf/|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u162-b12/0da788060d494f5095bf8624735fa2f1/|' oracle-java8-installer.*
+    sed -i 's|SHA256SUM_TGZ="c78200ce409367b296ec39be4427f020e2c585470c4eed01021feada576f027f"|SHA256SUM_TGZ="68ec82d47fd9c2b8eb84225b6db398a72008285fafc98631b1ff8d2229680257"|' oracle-java8-installer.*
+    sed -i 's|J_DIR=jdk1.8.0_151|J_DIR=jdk1.8.0_162|' oracle-java8-installer.*
+
 - name: Install java installer
   apt: name={{ item }}
   with_items: 


### PR DESCRIPTION
Due to some clean up on Oracle website, old java versions were removed.
Unfortunatly, the oracle ppa is not up to date and references a version which has been removed (8u152).

Until the maintainer of this ppa (Alin Andrei) update it, we need to change the version of Java inside the java-installer.

The ppa can be found here: https://launchpad.net/~webupd8team/+archive/ubuntu/java
An explanation about the workaround can be found here: https://ubuntuforums.org/showthread.php?t=2374686&page=4