### PR TITLE
[Ansible] fix when statements

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,4 +37,4 @@
 
 - name: Install Java Cryptography Extension
   apt: name=oracle-java8-unlimited-jce-policy
-  when: '{{ install_cryptography_extension }}'
+  when: install_cryptography_extension

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,4 +37,4 @@
 
 - name: Install Java Cryptography Extension
   apt: name=oracle-java8-unlimited-jce-policy
-  when: install_cryptography_extension
+  when: install_cryptography_extension|bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
 - apt:
     update_cache: yes
   when: java8_apt_key.changed
-  
+
 - name: Install debconf-utils
   apt:
     name: debconf-utils
@@ -31,7 +31,7 @@
 
 - name: Install java installer
   apt: name={{ item }}
-  with_items: 
+  with_items:
   - oracle-java8-installer
   - oracle-java8-set-default
 


### PR DESCRIPTION
- fix this warning:
  ```
  [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ install_cryptography_extension }}
  ```
- `install_cryptography_extension` might be set on the command line: [convert it](http://docs.ansible.com/ansible/latest/playbooks_variables.html#passing-variables-on-the-command-line)
- remove trailing space