### PR TITLE
Travis: retry when dependencies installation fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ env:
   - ANSIBLE_REF='ansible<2.5' BASE_IMAGE=debian:stretch
 
 install:
-  - pip install --upgrade pip setuptools wheel
-  - pip install "${ANSIBLE_REF}" molecule docker-py
+  - travis_retry pip install --upgrade pip setuptools wheel
+  - travis_retry pip install "${ANSIBLE_REF}" molecule docker-py
 
 script:
   - molecule test --driver-name docker


### PR DESCRIPTION
CI: Workaround network errors (like this [one](https://travis-ci.org/peopledoc/ansible-role-oracle-java/jobs/367226851#L447)) using `travis_retry`.