### PR TITLE
Ref peopledoc/tribe-java#570 - Change Java keystore password

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
 
 env:
   matrix:
-  - ANSIBLE_REF='ansible<2.6' BASE_IMAGE=ubuntu:xenial
-  - ANSIBLE_REF='ansible<2.6' BASE_IMAGE=debian:stretch
+  - ANSIBLE_REF='ansible==2.5.0' BASE_IMAGE=ubuntu:xenial
+  - ANSIBLE_REF='ansible==2.5.0' BASE_IMAGE=debian:stretch
   - ANSIBLE_REF='ansible<2.5' BASE_IMAGE=ubuntu:xenial
   - ANSIBLE_REF='ansible<2.5' BASE_IMAGE=debian:stretch
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,5 @@
 install_cryptography_extension: False
 ca_certificates:
   certificates: []
-  password: ""
+  password: "changeit"
+default_keystore_password: "changeit"

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -10,4 +10,4 @@
           - alias: dummy-test
             path: /usr/local/share/ca-certificates/dummy.crt
           - url: google.com
-        password: changeit
+        password: test123

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -39,11 +39,25 @@ def test_binaries(host):
     assert java_version == 'java version "%s"' % javac_version
 
 
-def test_certificates(host):
+def test_keystore_pass_changed(host):
+
+    # Check default password is no longer working
     cmd = "keytool -list -storepass changeit "
     cmd += "-keystore /usr/lib/jvm/java-8-oracle/jre/lib/security/cacerts"
     run = host.run(cmd)
-    print(run.stdout)
+    assert run.rc == 1
+
+    # Check the new password is working
+    cmd = "keytool -list -storepass test123 "
+    cmd += "-keystore /usr/lib/jvm/java-8-oracle/jre/lib/security/cacerts"
+    run = host.run(cmd)
+    assert run.rc == 0
+
+
+def test_certificates(host):
+    cmd = "keytool -list -storepass test123 "
+    cmd += "-keystore /usr/lib/jvm/java-8-oracle/jre/lib/security/cacerts"
+    run = host.run(cmd)
     assert run.rc == 0
     assert "google.com" in run.stdout
     assert "dummy-test" in run.stdout

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,16 @@
   apt: name=oracle-java8-unlimited-jce-policy
   when: install_cryptography_extension|bool
 
+- name: Check if Java keystore use default password
+  command: keytool -list -keystore /usr/lib/jvm/java-8-oracle/jre/lib/security/cacerts -storepass {{ default_keystore_password }}
+  register: keytool_list
+  ignore_errors: yes
+  changed_when: false
+
+- name: Set Java keystore password
+  command: keytool -storepasswd -new {{ ca_certificates.password }} -storepass {{ default_keystore_password }} -keystore /usr/lib/jvm/java-8-oracle/jre/lib/security/cacerts 
+  when: keytool_list is success
+
 - name: Add CA certificates to Java keystore
   java_cert:
     cert_alias: "{{ item.alias|default(omit) }}"


### PR DESCRIPTION
Ref peopledoc/tribe-java#570

Motivation:
* Improve Java keystore security by changing the default password

Modification:
* Use the password given with the CA certificates to set the
  default password of the Java keystore