### PR TITLE
[CI] ansible: use latest release & enable Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
 
 env:
   matrix:
-  - ANSIBLE_REF='ansible==2.5.0' BASE_IMAGE=ubuntu:xenial
-  - ANSIBLE_REF='ansible==2.5.0' BASE_IMAGE=debian:stretch
+  - ANSIBLE_REF='ansible<2.6' BASE_IMAGE=ubuntu:xenial
+  - ANSIBLE_REF='ansible<2.6' BASE_IMAGE=debian:stretch
   - ANSIBLE_REF='ansible<2.5' BASE_IMAGE=ubuntu:xenial
   - ANSIBLE_REF='ansible<2.5' BASE_IMAGE=debian:stretch
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: trusty
 language: python
 python:
 - '2.7'
+- '3.6'
 
 env:
   matrix:


### PR DESCRIPTION
CI:
- Ansible version was pinned due to an incompatibility between testinfra and Ansible 2.5.0, this issue has been fixed with testinfra 1.12.0.
- use Python 3 too