### PR TITLE
Hide sensitive information: use no_log at task level

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,10 +50,12 @@
   register: keytool_list
   ignore_errors: yes
   changed_when: false
+  no_log: true
 
 - name: Set Java keystore password
   command: keytool -storepasswd -new {{ ca_certificates.password }} -storepass {{ default_keystore_password }} -keystore /usr/lib/jvm/java-8-oracle/jre/lib/security/cacerts 
   when: keytool_list is success
+  no_log: true
 
 - name: Add CA certificates to Java keystore
   java_cert:


### PR DESCRIPTION
Output with `no_log`:
```
TASK [ansible-role-oracle-java
 : Check if Java keystore use default password] ***
task path: tasks/main.yml:48
ok: [jenkins-tester] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}

TASK [ansible-role-oracle-java
 : Set Java keystore password] ***
task path: tasks/main.yml:55
changed: [jenkins-tester] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": true}
```