### PR TITLE
Move 'Install Java Cryptography Extension' task in dedicated tasks file

### DIFF
--- a/tasks/cryptography_extension.yml
+++ b/tasks/cryptography_extension.yml
@@ -1,0 +1,3 @@
+- name: Install Java Cryptography Extension
+  apt:
+    name: oracle-java8-unlimited-jce-policy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,8 +41,7 @@
   - oracle-java8-installer
   - oracle-java8-set-default
 
-- name: Install Java Cryptography Extension
-  apt: name=oracle-java8-unlimited-jce-policy
+- import_tasks: cryptography_extension.yml
   when: install_cryptography_extension|bool
 
 - name: Check if Java keystore use default password


### PR DESCRIPTION
Move `Install Java Cryptography Extension` task in dedicated tasks file in order to be able to reuse this task only.

This PR assumes that `oracle-java8-unlimited-jce-policy` package installation has no impact on tasks following this one.

Do not merge without Eliah approval.