### PR TITLE
apt: 'name' parameter handles list

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,10 +36,10 @@
     creates: /root/.oracle-license-accepted
 
 - name: Install java installer
-  apt: name={{ item }}
-  with_items:
-  - oracle-java8-installer
-  - oracle-java8-set-default
+  apt:
+    name:
+      - oracle-java8-installer
+      - oracle-java8-set-default
 
 - import_tasks: cryptography_extension.yml
   when: install_cryptography_extension|bool


### PR DESCRIPTION
implicit squashing is [deprecated since Ansible 2.7](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.7.html#using-a-loop-on-a-package-module-via-squash-actions).